### PR TITLE
Better ros topics

### DIFF
--- a/camera/launch/camera.launch
+++ b/camera/launch/camera.launch
@@ -1,5 +1,6 @@
 <launch>
-	<group ns="camera_right">
+	<arg name="side"/>
+	<group ns="$(arg side)">
 		<node name="pi_cam" pkg="raspicam" type="raspicam_node" args="_width:=200 _height:=200"/>
 		<node name="video_server" pkg="web_video_server" type="web_video_server" args="_image_transport:=compressed"/>
 	</group>

--- a/camera/launch/camera_left.launch
+++ b/camera/launch/camera_left.launch
@@ -1,6 +1,0 @@
-<launch>
-	<group ns="camera_left">
-		<node name="pi_cam" pkg="raspicam" type="raspicam_node" args="_width:=200 _height:=200"/>
-		<node name="video_server" pkg="web_video_server" type="web_video_server" args="_image_transport:=compressed"/>
-	</group>
-</launch>

--- a/image/image_viewer_fs/launch/image_viewer_fs.launch
+++ b/image/image_viewer_fs/launch/image_viewer_fs.launch
@@ -1,23 +1,6 @@
 <launch>
-	<include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" />
-	<group ns="image/left">
-
-		<node name="rostopic_image_show2" pkg="rostopic" type="rostopic" args="pub /image/left/show std_msgs/Bool true -r 1.0"/>
-		<node name="rostopic_angle" pkg="rostopic" type="rostopic" args="pub /image/left/angle std_msgs/Float32 90.0 -r 0.5"/>
-		<node name="rostopic_angle2" pkg="rostopic" type="rostopic" args="pub /image/left/angle std_msgs/Float32 45.0 -r 0.25"/>
-		<node name="rostopic_scale" pkg="rostopic" type="rostopic" args="pub /image/left/scale std_msgs/Float32 0.5 -r 1"/>
-		<node name="rostopic_filename" pkg="rostopic" type="rostopic" args="pub /image/left/filename std_msgs/String oct_in_square/left.jpg -r 0.5"/>
-
-		<param name="image_directory" type="str" value="$(optenv STRABUS_IMAGE_DIR /home/pi/Strabus/UI/app/img/)" />
-		<node name="image_viewer" pkg="image_viewer_fs" type="image_viewer_fs_node" output="screen"/>
-	</group>
-	<group ns="image/right">
-
-		<node name="rostopic_image_show2" pkg="rostopic" type="rostopic" args="pub /image/right/show std_msgs/Bool true -r 1.0"/>
-		<node name="rostopic_angle" pkg="rostopic" type="rostopic" args="pub /image/right/angle std_msgs/Float32 90.0 -r 0.5"/>
-		<node name="rostopic_angle2" pkg="rostopic" type="rostopic" args="pub /image/right/angle std_msgs/Float32 45.0 -r 0.25"/>
-		<node name="rostopic_scale" pkg="rostopic" type="rostopic" args="pub /image/right/scale std_msgs/Float32 0.5 -r 1"/>
-		<node name="rostopic_filename" pkg="rostopic" type="rostopic" args="pub /image/right/filename std_msgs/String oct_in_square/right.jpg -r 0.5"/>			
+	<arg name="side"/>
+	<group ns="$(arg side)/image">
 		<param name="image_directory" type="str" value="$(optenv STRABUS_IMAGE_DIR /home/pi/Strabus/UI/app/img/)" />
 		<node name="image_viewer" pkg="image_viewer_fs" type="image_viewer_fs_node" output="screen"/>
 	</group>

--- a/image/image_viewer_fs/src/imageViewer.cpp
+++ b/image/image_viewer_fs/src/imageViewer.cpp
@@ -20,9 +20,6 @@ float g_angle = 90.0f;
 float g_showImage = true;
 std::string g_filename = "";
 std::string g_imageDirectory = "/home/jon/Projects/Strabus/UI/app/img/";
-//std::string g_imageDirectory = "/home/jon/";
-
-std::string g_nodeName = "";
 
 std::map<std::string, cv::Mat> g_images;
 std::mutex g_mapMutex; // write: unique access, read: shared access
@@ -195,10 +192,10 @@ int main(int argc, char **argv)
     }
     ROS_INFO("Image directory : %s\n", g_imageDirectory.c_str());
 
-    ros::Subscriber angleSub = nh.subscribe(g_nodeName + "angle", 1000, angleCallback);
-    ros::Subscriber filenameSub = nh.subscribe(g_nodeName + "filename", 1000, filenameCallback);
-    ros::Subscriber scaleSub = nh.subscribe(g_nodeName + "scale", 1000, scaleCallback);
-    ros::Subscriber imageShowSub = nh.subscribe(g_nodeName + "show", 1000, imageShowCallback);
+    ros::Subscriber angleSub = nh.subscribe("angle", 1000, angleCallback);
+    ros::Subscriber filenameSub = nh.subscribe("filename", 1000, filenameCallback);
+    ros::Subscriber scaleSub = nh.subscribe("scale", 1000, scaleCallback);
+    ros::Subscriber imageShowSub = nh.subscribe("show", 1000, imageShowCallback);
 
     cv::namedWindow("view", CV_WINDOW_NORMAL);
     cv::setWindowProperty("view", CV_WND_PROP_FULLSCREEN, CV_WINDOW_FULLSCREEN);


### PR DESCRIPTION
Put left or right before nodes so we can launch them in batch.
Generalize launch files with left or right as arguments (for image_viewer_fs and camera).
So we only need one launch file for camera now.

launch with : roslaunch package launchfile.launch side:=left
